### PR TITLE
storj-lib version changed from 8.7.3-beta to b1 branch

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "ms": "^2.1.2",
     "proxyquire": "^2.1.3",
     "random-word": "^2.0.0",
-    "storj-lib": "github:StorXNetwork/core#v8.7.3-beta",
+    "storj-lib": "github:StorXNetwork/core#b1",
     "storj-service-error-types": "github:StorXNetwork/service-error-types",
     "stripe": "^8.19.0",
     "uuid": "^3.4.0",


### PR DESCRIPTION
Reason: 
-- Possible fix for "Point does lie on the curve" issue when running renter.js program

Explanation:
-- complex repo uses "b1" branch  of core repo while this repo uses v8.7.3-beta version of "core" repo. The beta version runs on very old version of node and maybe that is why this is causing that issue.